### PR TITLE
[fixed]デプロイとビルドについてgithubアクションでvercelにデプロイ

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -21,6 +21,6 @@ jobs:
           token: ${{ secrets.VERCEL_TOKEN }}
           org-id: ${{ secrets.VERCEL_ORG_ID }}
           project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PORTFOLIO_SITE_GITHUB_TOKEN }}
           production: ${{ github.ref == 'refs/heads/main' }} # main ブランチにpushされたら本番環境にデプロイする
           prebuilt: true

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -1,0 +1,26 @@
+name: Vercel
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      statuses: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: nexterias/actions-vercel@v1
+        with:
+          token: ${{ secrets.VERCEL_TOKEN }}
+          org-id: ${{ secrets.VERCEL_ORG_ID }}
+          project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          production: ${{ github.ref == 'refs/heads/main' }} # main ブランチにpushされたら本番環境にデプロイする
+          prebuilt: true


### PR DESCRIPTION
# Vercelのデプロイについて

[デプロイ参考サイト](https://zenn.dev/inkohx/articles/561306a5520ead)

Vercelを採用した経緯
- 3Dを使ったサイトになるのでgithub Pagesでは役不足
- Vercelはnext.jsに特化したデプロイ先であり、サーバーレンダリングに長けている
- 無料ででデプロイが可能
- [デプロイしたアプリのURL](https://portfolio-site-j70pstok4-ais-projects-d11ce2c7.vercel.app/)

# Github Actionについて

- 自動デプロイを採用したかったため使用
- mainにpush時に動作
- github actionを使用してビルドし、デプロイをVercelにする流れでのワークフロー作成
- デフォルトの権限ではPRからマージできない（mainから直接pushしないといけない）のでPersonal Tokenを作成して強めの権限を作成して対応